### PR TITLE
[GCCR-211] Add sale or authorisation choice

### DIFF
--- a/app.js
+++ b/app.js
@@ -77,7 +77,7 @@ function createCheckoutSession(req, res) {
 
   let payment = {
     methods: ['cc', 'mb', 'mbw', 'dd', 'vi', 'uf', 'sc', 'ap'],
-    type: 'sale',
+    type: req.query.operation || 'sale',
     capture: {
       transaction_key: 'string',
       descriptive: 'Descriptive Example',

--- a/index.html
+++ b/index.html
@@ -31,6 +31,13 @@
         <!-- Configurations -->
         <h3>Configuration:</h3>
         <div class="option">
+          <label for="operation">Sale / Authorisation</label>
+          <select id="operation" name="operation">
+            <option value="sale">Sale</option>
+            <option value="authorisation">Authorisation</option>
+          </select>
+        </div>
+        <div class="option">
           <label for="switch">Hide details</label>
           <div id="switch" class="switch" onclick="toggleHideDetails()">
             <input type="checkbox" id="hideDetails" />
@@ -168,6 +175,7 @@
   }
 
   function submitConfig() {
+    const operation = document.getElementById('operation')
     const hideDetails = document.getElementById('hideDetails')
     const logoUrl = document.getElementById('logoUrl')
     const fontFamily = document.getElementById('fontFamily')
@@ -175,6 +183,7 @@
     advancedOptions.push(fontFamily)
 
     setPaymentType()
+    sessionStorage.setItem(operation.id, operation.value)
     sessionStorage.setItem(hideDetails.id, hideDetails.checked ? 'true' : 'false')
     sessionStorage.setItem(logoUrl.id, logoUrl.checked ? 'true' : 'false')
 

--- a/inline.html
+++ b/inline.html
@@ -90,7 +90,8 @@
             }
           }
         }
-        const url = `/checkoutmanifest/${sessionStorage.getItem('paymentType')}`
+        const operation = sessionStorage.getItem('operation') || 'sale'
+        const url = `/checkoutmanifest/${sessionStorage.getItem('paymentType')}?operation=${operation}`
         req.open('GET', url)
         req.send()
       }

--- a/popup.html
+++ b/popup.html
@@ -102,7 +102,8 @@
             }
           }
         }
-        const url = `/checkoutmanifest/${sessionStorage.getItem('paymentType')}`
+        const operation = sessionStorage.getItem('operation') || 'sale'
+        const url = `/checkoutmanifest/${sessionStorage.getItem('paymentType')}?operation=${operation}`
         req.open('GET', url)
         req.send()
       }


### PR DESCRIPTION
I used "operation" id internally because "payment type" is already present everywhere, but for the user I display the label "Sale / Authorisation" to be consistent with the [documentation](https://docs.easypay.pt/#section/Authorisations-and-Captures).

![Screenshot 2024-04-03 at 17 04 23](https://github.com/Easypay/checkout-demo/assets/2780456/86be3f5a-639f-4c62-bb08-e156d6710a86)

